### PR TITLE
Fix semantic imports issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+PHONY: develop
+develop:
+	swift package generate-xcodeproj --xcconfig-overrides Settings.xcconfig
+	xed Example.xcodeproj

--- a/Settings.xcconfig
+++ b/Settings.xcconfig
@@ -1,0 +1,2 @@
+CLANG_ENABLE_MODULES = YES
+HEADER_SEARCH_PATHS = $(inherited) $(PROJECT_FILE_PATH)/GeneratedModuleMap/


### PR DESCRIPTION
Finally figured out a better fix than https://github.com/fdiaz/SPM-Semantic-Imports/pull/1 for the

> Use of '@import' when modules are disabled

issue.

Big thanks to @qyang-nj for pointing me in the right direction!